### PR TITLE
Add Permissions checking on `handle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ module.exports.help = {
     requires: ['botowner', 'guild', 'dm'],
 	usage: '<prefix>cmdname',   // <prefix> gets replaced with the prefix
 	aliases: ['cmdalias'],
+	requiresBotPermissions: ['EMBED_LINKS'], // Array containing Permissions that need to be checked, SEND_MESSAGES, is included automatically
 	// cooldownGroup: 'example' || use this to cooldown all the commands in that group
 };  // to get a category just make a sub-folder
 ```
@@ -49,6 +50,7 @@ module.exports = new Command({
     requires: ['botowner', 'guild', 'dm'],
 	usage: '<prefix>cmdname',   // <prefix> gets replaced with the prefix
 	aliases: ['cmdalias'],
+	requiresBotPermissions: ['EMBED_LINKS'], // Array containing Permissions that need to be checked, SEND_MESSAGES, is included automatically
 	// cooldownGroup: 'example' || use this to cooldown all the commands in that group
 	// to get a category just make a sub-folder
 	}).execute((client, message, args) => {

--- a/src/Command.js
+++ b/src/Command.js
@@ -7,7 +7,7 @@ class Command {
 	 */
 	/**
 	 *
-	 * @param {{name:string,description:string,hideinhelp:boolean,requires:Requires[],usage:string,aliases:Array<string>,clientPermissions:Discord.PermissionResolvable[]}} param0
+	 * @param {{name:string,description:string,hideinhelp:boolean,requires:Requires[],usage:string,aliases:Array<string>,requirePermissions:Discord.PermissionResolvable[]}} param0
 	 */
 	constructor({
 		name,
@@ -16,7 +16,7 @@ class Command {
 		requires = [],
 		usage,
 		aliases = [],
-		clientPermissions = [],
+		requirePermissions = [],
 	}) {
 		if (!name) {
 			throw new Error('name required for Command Class');
@@ -28,7 +28,7 @@ class Command {
 		this.help.requires = requires;
 		this.help.usage = usage;
 		this.help.aliases = aliases;
-		this.help.clientPermissions = clientPermissions;
+		this.help.requirePermissions = requirePermissions;
 		this.run = () => {};
 		return this;
 	}

--- a/src/Command.js
+++ b/src/Command.js
@@ -7,7 +7,7 @@ class Command {
 	 */
 	/**
 	 *
-	 * @param {{name:string,description:string,hideinhelp:boolean,requires:Requires[],usage:string,aliases:Array<string>,requirePermissions:Discord.PermissionResolvable[]}} param0
+	 * @param {{name:string,description:string,hideinhelp:boolean,requires:Requires[],usage:string,aliases:Array<string>,requiresBotPermissions:Discord.PermissionResolvable[]}} param0
 	 */
 	constructor({
 		name,
@@ -16,7 +16,7 @@ class Command {
 		requires = [],
 		usage,
 		aliases = [],
-		requirePermissions = [],
+		requiresBotPermissions = [],
 	}) {
 		if (!name) {
 			throw new Error('name required for Command Class');
@@ -28,7 +28,7 @@ class Command {
 		this.help.requires = requires;
 		this.help.usage = usage;
 		this.help.aliases = aliases;
-		this.help.requirePermissions = requirePermissions;
+		this.help.requiresBotPermissions = requiresBotPermissions;
 		this.run = () => {};
 		return this;
 	}

--- a/src/Command.js
+++ b/src/Command.js
@@ -2,12 +2,12 @@
 const Discord = require('discord.js');
 class Command {
 	/**
-     *
-     * @typedef {'botowner'|'guild'|'dm'} Requires
-     */
+	 *
+	 * @typedef {'botowner'|'guild'|'dm'} Requires
+	 */
 	/**
 	 *
-	 * @param {{name:string,description:string,hideinhelp:boolean,requires:Requires[],usage:string,aliases:Array<string>}} param0
+	 * @param {{name:string,description:string,hideinhelp:boolean,requires:Requires[],usage:string,aliases:Array<string>,clientPermissions:Discord.PermissionResolvable[]}} param0
 	 */
 	constructor({
 		name,
@@ -16,6 +16,7 @@ class Command {
 		requires = [],
 		usage,
 		aliases = [],
+		clientPermissions = [],
 	}) {
 		if (!name) {
 			throw new Error('name required for Command Class');
@@ -27,6 +28,7 @@ class Command {
 		this.help.requires = requires;
 		this.help.usage = usage;
 		this.help.aliases = aliases;
+		this.help.clientPermissions = clientPermissions;
 		this.run = () => {};
 		return this;
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,11 @@ class CommandHandler {
 			message.channel.startTyping();
 			if (cmd.help.disableindm == true) return message.channel.send('Sorry this Command is not yet supported!'), message.channel.stopTyping(true); // check if command is supported in dm if not => return
 			console.log(`[Ping:${Math.round(client.ping)}ms] ${cmd.help.name} request by ${message.author.username} @ ${message.author.id} `); // if command can run => log action
+			if(cmd.help.requirePermissions && cmd.help.requirePermissions.length > 0) {
+				if(!message.guild.me.hasPermission(cmd.help.requirePermissions)) {
+					return message.reply('missing permissions to execute command'), message.channel.stopTyping(true);
+				}
+			}
 			if (cmd.help.requires) {
 				if (cmd.help.requires.includes('botowner')) if (!client.owners.includes(message.author.id)) return message.reply('This command cannot be used by you!'), console.log(`[Ping:${Math.round(client.ping)}ms] ${cmd.help.name} failed!: Not Bot Owner! `), message.channel.stopTyping(true);
 				if (cmd.help.requires.includes('guild') && message.channel.type !== 'text') return message.channel.send('This command needs to be run in a guild!'), console.log(`[Ping:${Math.round(client.ping)}ms] ${cmd.help.name} failed!: Not Guild! `), message.channel.stopTyping(true);
@@ -152,11 +157,6 @@ class CommandHandler {
 				}
 				cooldowns[cooldownName] = now;
 				client.cooldowns.set(message.author.id, cooldowns);
-			}
-			if(cmd.help.requirePermissions && cmd.help.requirePermissions.length > 0) {
-				if(!message.guild.me.hasPermission(cmd.help.requirePermissions)) {
-					return message.reply('missing permissions to execute command'), message.channel.stopTyping(true);
-				}
 			}
 			cmd.run(client, message, args);
 			if (cmd.help.category === 'indevelopment' && !client.owners.includes(message.author.id)) message.reply('Just a quick sidenote:\nThis Command is still indevelopment and might be unstable or even broken!');

--- a/src/index.js
+++ b/src/index.js
@@ -119,6 +119,7 @@ class CommandHandler {
  	* @example commandhandler.run(client, message);
  	*/
 	handle(client, message) {
+		if(message.guild && !message.channel.permissionsFor(message.guild.me).has('SEND_MESSAGES')) return;
 		if (message.system) return;
 		if (message.author.bot) return;
 		const prefixRegex = new RegExp(`^(<@!?${client.user.id}>|\\${client.prefix})\\s*`);

--- a/src/index.js
+++ b/src/index.js
@@ -155,7 +155,7 @@ class CommandHandler {
 			}
 			if(cmd.help.requirePermissions && cmd.help.requirePermissions.length>0){
 				if(!message.guild.me.hasPermission(cmd.help.requirePermissions)){
-					return message.reply('missing permissions to execute command')
+					return message.reply('missing permissions to execute command'),message.channel.stopTyping(true)
 				}
 			}
 			cmd.run(client, message, args);

--- a/src/index.js
+++ b/src/index.js
@@ -133,6 +133,8 @@ class CommandHandler {
 			console.log(`[Ping:${Math.round(client.ping)}ms] ${cmd.help.name} request by ${message.author.username} @ ${message.author.id} `); // if command can run => log action
 			if(cmd.help.requiresBotPermissions && cmd.help.requiresBotPermissions.length > 0) {
 				if(!message.guild) return message.channel.send('I need special Permissions for this, but this is a DM.'), message.channel.stopTyping(true);
+				const missing = cmd.help.requiresBotPermissions.filter(permission => message.guild.me.hasPermission(permission));
+				if(missing.length)return message.reply(`I am missing the following Permissions to execute this Command: ${missing.map(x => `\`${x}\``).join(', ')}`), message.channel.stopTyping(true);
 			}
 			if (cmd.help.requires) {
 				if (cmd.help.requires.includes('botowner')) if (!client.owners.includes(message.author.id)) return message.reply('This command cannot be used by you!'), console.log(`[Ping:${Math.round(client.ping)}ms] ${cmd.help.name} failed!: Not Bot Owner! `), message.channel.stopTyping(true);

--- a/src/index.js
+++ b/src/index.js
@@ -153,6 +153,11 @@ class CommandHandler {
 				cooldowns[cooldownName] = now;
 				client.cooldowns.set(message.author.id, cooldowns);
 			}
+			if(cmd.help.clientPermissions && cmd.help.clientPermissions.length>0){
+				if(message.guild.me.hasPermission(cmd.help.clientPermissions)){
+					return message.reply('missing permissions to execute command')
+				}
+			}
 			cmd.run(client, message, args);
 			if (cmd.help.category === 'indevelopment' && !client.owners.includes(message.author.id)) message.reply('Just a quick sidenote:\nThis Command is still indevelopment and might be unstable or even broken!');
 			message.channel.stopTyping(true);

--- a/src/index.js
+++ b/src/index.js
@@ -153,9 +153,9 @@ class CommandHandler {
 				cooldowns[cooldownName] = now;
 				client.cooldowns.set(message.author.id, cooldowns);
 			}
-			if(cmd.help.requirePermissions && cmd.help.requirePermissions.length>0){
-				if(!message.guild.me.hasPermission(cmd.help.requirePermissions)){
-					return message.reply('missing permissions to execute command'),message.channel.stopTyping(true)
+			if(cmd.help.requirePermissions && cmd.help.requirePermissions.length > 0) {
+				if(!message.guild.me.hasPermission(cmd.help.requirePermissions)) {
+					return message.reply('missing permissions to execute command'), message.channel.stopTyping(true);
 				}
 			}
 			cmd.run(client, message, args);

--- a/src/index.js
+++ b/src/index.js
@@ -153,8 +153,8 @@ class CommandHandler {
 				cooldowns[cooldownName] = now;
 				client.cooldowns.set(message.author.id, cooldowns);
 			}
-			if(cmd.help.clientPermissions && cmd.help.clientPermissions.length>0){
-				if(message.guild.me.hasPermission(cmd.help.clientPermissions)){
+			if(cmd.help.requirePermissions && cmd.help.requirePermissions.length>0){
+				if(!message.guild.me.hasPermission(cmd.help.requirePermissions)){
 					return message.reply('missing permissions to execute command')
 				}
 			}

--- a/src/index.js
+++ b/src/index.js
@@ -131,8 +131,8 @@ class CommandHandler {
 			message.channel.startTyping();
 			if (cmd.help.disableindm == true) return message.channel.send('Sorry this Command is not yet supported!'), message.channel.stopTyping(true); // check if command is supported in dm if not => return
 			console.log(`[Ping:${Math.round(client.ping)}ms] ${cmd.help.name} request by ${message.author.username} @ ${message.author.id} `); // if command can run => log action
-			if(cmd.help.requirePermissions && cmd.help.requirePermissions.length > 0) {
-				if(!message.guild.me.hasPermission(cmd.help.requirePermissions)) {
+			if(cmd.help.requiresBotPermissions && cmd.help.requiresBotPermissions.length > 0) {
+				if(!message.guild.me.hasPermission(cmd.help.requiresBotPermissions)) {
 					return message.reply('missing permissions to execute command'), message.channel.stopTyping(true);
 				}
 			}

--- a/src/index.js
+++ b/src/index.js
@@ -132,8 +132,13 @@ class CommandHandler {
 			if (cmd.help.disableindm == true) return message.channel.send('Sorry this Command is not yet supported!'), message.channel.stopTyping(true); // check if command is supported in dm if not => return
 			console.log(`[Ping:${Math.round(client.ping)}ms] ${cmd.help.name} request by ${message.author.username} @ ${message.author.id} `); // if command can run => log action
 			if(cmd.help.requiresBotPermissions && cmd.help.requiresBotPermissions.length > 0) {
-				if(!message.guild) return message.channel.send('I need special Permissions for this, but this is a DM.'), message.channel.stopTyping(true);
-				const missing = cmd.help.requiresBotPermissions.filter(permission => message.guild.me.hasPermission(permission));
+				let missing = ['ERROR'];
+				if(message.guild) {
+					missing = cmd.help.requiresBotPermissions.filter(permission => message.guild.me.hasPermission(permission));
+				}
+				else {
+					missing = cmd.help.requiresBotPermissions.filter(permission => !['VIEW_CHANNEL', 'SEND_MESSAGES', 'EMBED_LINKS', 'ADD_REACTIONS ', 'ATTACH_FILES'].includes(permission));
+				}
 				if(missing.length)return message.reply(`I am missing the following Permissions to execute this Command: ${missing.map(x => `\`${x}\``).join(', ')}`), message.channel.stopTyping(true);
 			}
 			if (cmd.help.requires) {

--- a/src/index.js
+++ b/src/index.js
@@ -132,9 +132,7 @@ class CommandHandler {
 			if (cmd.help.disableindm == true) return message.channel.send('Sorry this Command is not yet supported!'), message.channel.stopTyping(true); // check if command is supported in dm if not => return
 			console.log(`[Ping:${Math.round(client.ping)}ms] ${cmd.help.name} request by ${message.author.username} @ ${message.author.id} `); // if command can run => log action
 			if(cmd.help.requiresBotPermissions && cmd.help.requiresBotPermissions.length > 0) {
-				if(!message.guild.me.hasPermission(cmd.help.requiresBotPermissions)) {
-					return message.reply('missing permissions to execute command'), message.channel.stopTyping(true);
-				}
+				if(!message.guild) return message.channel.send('I need special Permissions for this, but this is a DM.'), message.channel.stopTyping(true);
 			}
 			if (cmd.help.requires) {
 				if (cmd.help.requires.includes('botowner')) if (!client.owners.includes(message.author.id)) return message.reply('This command cannot be used by you!'), console.log(`[Ping:${Math.round(client.ping)}ms] ${cmd.help.name} failed!: Not Bot Owner! `), message.channel.stopTyping(true);


### PR DESCRIPTION
allows for the client to check for `requirePermissions` property on the command and if its not empty, test if the client has the required permissions on that server
- [x] updated `Command` to have this property
- [x] includes all discord.js permissions
- [x] has been tested 